### PR TITLE
accessible loading, error, and refreshing states with deterministic E2E

### DIFF
--- a/docs/sprint-planning.md
+++ b/docs/sprint-planning.md
@@ -143,10 +143,50 @@ Completed On: 2025-08-24
   - statements: 60%
   - branches: 70%
 
-
-
 ---
 
+## 🟡 User Story 7: Handle UI Loading & Error States (Portfolio Page)
+
+> As a user relying on timely price data,
+> I want clear loading and error feedback with accessible states,
+> so that I understand what the app is doing and can retry when something goes wrong.
+
+### ✅ Acceptance Criteria
+
+- [x] 7.1 Initial load shows a prominent loading indicator; controls disabled.
+- [x] 7.2 On background refresh, subtle loading state: controls disabled, `aria-busy` set on main container.
+- [x] 7.3 On fetch error, an error banner appears with a Retry action.
+- [x] 7.4 Retry clears the error and refetches data; controls usable after recovery.
+- [x] 7.5 Accessibility: `aria-busy` and `role="alert"` used appropriately; disabled controls have visual cues.
+
+### 🔧 Technical Breakdown
+
+| Layer / Role            | Task                                                                 | File(s) / Module(s)                                      | Owner     | Status   |
+| ----------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- | --------- | -------- |
+| Page UI                 | Add `aria-busy` on main container during load/refresh                 | `src/pages/PortfolioPage.tsx`                            | Developer | ✅ Done  |
+| Controls UX             | Disabled affordances (opacity, cursor) when `disabled`               | `src/components/FilterSortControls/index.tsx`            | Developer | ✅ Done  |
+| Error UI                | Ensure error banner with Retry is accessible and discoverable        | `src/components/ErrorBanner.tsx`                         | Developer | ✅ Done  |
+| Data Hook               | Expose `loading`, `error`, `refreshing`, and `retry()`               | `src/hooks/useCoinList.ts`                               | Developer | ✅ Done  |
+| Unit/Wiring Tests       | Verify wiring of loading/refreshing/disabled/error states            | `src/__tests__/pages/PortfolioPage.wiring.test.tsx`      | Developer | ✅ Done  |
+| E2E – Retry Flow        | Failure then success on retry; controls usable before/after          | `src/e2e/specs/flows/retry-reenable-controls.spec.ts`    | Developer | ✅ Done  |
+| E2E – Refreshing State  | Controls disabled + `aria-busy` during polling refresh               | `src/e2e/specs/flows/refreshing-disabled-controls.spec.ts` | Developer | ✅ Done  |
+
+### 📊 Status
+
+- Implementation complete; retry E2E passing; refreshing E2E now stable via test-only Refresh button (`/?e2e=1`) for deterministic CI. Behavior also covered by unit and wiring tests.  
+- Date: 2025-08-24
+
+### 🧪 Quality & Traceability
+
+- Latest Playwright run: 23 passed / 1 skipped (refresh test passing).  
+- `aria-busy` used to detect refresh in tests; disabled styles verified on controls.
+
+### 🔜 Follow-ups
+
+- Keep the test-only "Refresh now" trigger guarded by query param (`?e2e=1`); optionally guard further by environment if needed.
+- `data-testid="empty-state"` added in `AssetList` to reduce selector fragility in E2E.
+
+---
 ### 📦 Deliverables
 
 | Type        | File / Component                    |

--- a/frontend/src/__tests__/pages/PortfolioPage.wiring.test.tsx
+++ b/frontend/src/__tests__/pages/PortfolioPage.wiring.test.tsx
@@ -11,7 +11,11 @@ vi.mock("@components/AssetList", () => ({
     </div>
   ),
 }));
-vi.mock("@components/FilterSortControls", () => ({ default: () => <div data-testid="filter-sort" /> }));
+vi.mock("@components/FilterSortControls", () => ({
+  default: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid="filter-sort" data-disabled={disabled ? "true" : "false"} />
+  ),
+}));
 vi.mock("@components/PortfolioHeader", () => ({ default: () => <div data-testid="header" /> }));
 vi.mock("@components/AppFooter", () => ({ default: () => <div data-testid="footer" /> }));
 vi.mock("@components/AddAssetModal", () => ({ AddAssetModal: () => null }));
@@ -145,6 +149,10 @@ describe("PortfolioPage wiring", () => {
     // Add button should be disabled
     const addBtn = screen.getByTestId("add-asset-button");
     expect(addBtn).toBeDisabled();
+
+    // Filter/Sort controls should be disabled
+    const filterSort = screen.getByTestId("filter-sort");
+    expect(filterSort).toHaveAttribute("data-disabled", "true");
   });
 
   it("shows ImportPreviewModal when importPreview is present and triggers applyMerge", () => {

--- a/frontend/src/__tests__/pages/PortfolioPage.wiring.test.tsx
+++ b/frontend/src/__tests__/pages/PortfolioPage.wiring.test.tsx
@@ -4,7 +4,13 @@ import * as coinList from "@hooks/useCoinList";
 import PortfolioPage from "@pages/PortfolioPage";
 
 // Mock child components that are heavy/irrelevant for wiring
-vi.mock("@components/AssetList", () => ({ default: () => <div data-testid="asset-list" /> }));
+vi.mock("@components/AssetList", () => ({
+  default: ({ disabled }: { disabled?: boolean }) => (
+    <div>
+      <button data-testid="add-asset-button" disabled={!!disabled} />
+    </div>
+  ),
+}));
 vi.mock("@components/FilterSortControls", () => ({ default: () => <div data-testid="filter-sort" /> }));
 vi.mock("@components/PortfolioHeader", () => ({ default: () => <div data-testid="header" /> }));
 vi.mock("@components/AppFooter", () => ({ default: () => <div data-testid="footer" /> }));
@@ -12,7 +18,14 @@ vi.mock("@components/AddAssetModal", () => ({ AddAssetModal: () => null }));
 vi.mock("@components/DeleteConfirmationModal", () => ({ default: () => null }));
 
 vi.mock("@hooks/useCoinList", () => {
-  const impl = vi.fn(() => ({ coins: [], loading: false, error: null, lastUpdatedAt: new Date().toISOString() }));
+  const impl = vi.fn(() => ({
+    coins: [],
+    loading: false,
+    error: null,
+    lastUpdatedAt: Date.now(),
+    refreshing: false,
+    retry: vi.fn(),
+  }));
   return { useCoinList: impl };
 });
 vi.mock("@hooks/usePriceMap", () => ({ usePriceMap: () => ({}) }));
@@ -83,13 +96,55 @@ describe("PortfolioPage wiring", () => {
       dismissPreview: vi.fn(),
       exportPortfolio: vi.fn(),
     });
+  });
+
+  afterEach(() => {
     // reset useCoinList mock to default non-error state
-    (coinList.useCoinList as unknown as jest.Mock | vi.Mock).mockImplementation(() => ({
+    (coinList.useCoinList as unknown as vi.Mock).mockImplementation(() => ({
       coins: [],
       loading: false,
       error: null,
-      lastUpdatedAt: new Date().toISOString(),
+      lastUpdatedAt: Date.now(),
+      refreshing: false,
+      retry: vi.fn(),
     }));
+  });
+
+  it("invokes retry when clicking Retry on error banner", () => {
+    const retry = vi.fn();
+    (coinList.useCoinList as unknown as vi.Mock).mockImplementation(() => ({
+      coins: [],
+      loading: false,
+      error: "Network",
+      lastUpdatedAt: Date.now(),
+      refreshing: false,
+      retry,
+    }));
+
+    render(<PortfolioPage />);
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryBtn);
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it("shows updating spinner and disables add button when refreshing", () => {
+    (coinList.useCoinList as unknown as vi.Mock).mockImplementation(() => ({
+      coins: [],
+      loading: false,
+      error: null,
+      lastUpdatedAt: Date.now(),
+      refreshing: true,
+      retry: vi.fn(),
+    }));
+
+    render(<PortfolioPage />);
+
+    // Inline spinner should be present (role status from LoadingSpinner)
+    expect(screen.getAllByRole("status").length).toBeGreaterThan(0);
+
+    // Add button should be disabled
+    const addBtn = screen.getByTestId("add-asset-button");
+    expect(addBtn).toBeDisabled();
   });
 
   it("shows ImportPreviewModal when importPreview is present and triggers applyMerge", () => {
@@ -132,11 +187,13 @@ describe("PortfolioPage wiring", () => {
   });
 
   it("shows general error banner when coin list has an error", () => {
-    (coinList.useCoinList as unknown as jest.Mock | vi.Mock).mockImplementation(() => ({
+    (coinList.useCoinList as unknown as vi.Mock).mockImplementation(() => ({
       coins: [],
       loading: false,
       error: "Network",
-      lastUpdatedAt: new Date().toISOString(),
+      lastUpdatedAt: Date.now(),
+      refreshing: false,
+      retry: vi.fn(),
     }));
 
     // Ensure importError is null so only general error shows (plus no detailed import error message)

--- a/frontend/src/components/AssetList/index.tsx
+++ b/frontend/src/components/AssetList/index.tsx
@@ -8,6 +8,7 @@ type AssetListProps = {
   onAddAsset: () => void;
   addButtonRef: React.RefObject<HTMLButtonElement | null>;
   priceMap: Record<string, number>;
+  disabled?: boolean;
 };
 
 export default function AssetList({
@@ -16,6 +17,7 @@ export default function AssetList({
   onAddAsset,
   addButtonRef,
   priceMap,
+  disabled = false,
 }: AssetListProps) {
   return (
     <section className="flex flex-col gap-6 w-full p-6 sm:p-6 md:p-8">
@@ -27,9 +29,13 @@ export default function AssetList({
         <button
           ref={addButtonRef}
           onClick={onAddAsset}
-          className="bg-brand-primary text-white font-button px-4 py-2 rounded-md hover:bg-purple-700 flex items-center gap-2"
+          className={`bg-brand-primary text-white font-button px-4 py-2 rounded-md flex items-center gap-2 ${
+            disabled ? "opacity-60 cursor-not-allowed" : "hover:bg-purple-700"
+          }`}
           aria-label="Add Asset"
           data-testid="add-asset-button"
+          disabled={disabled}
+          aria-disabled={disabled}
         >
           <PlusIcon className="w-4 h-4" aria-hidden="true" />
           Add Asset

--- a/frontend/src/components/AssetList/index.tsx
+++ b/frontend/src/components/AssetList/index.tsx
@@ -44,7 +44,10 @@ export default function AssetList({
 
       {/* Asset List or Empty State */}
       {assets.length === 0 ? (
-        <div className="text-gray-500 italic text-center py-8">
+        <div
+          className="text-gray-500 italic text-center py-8"
+          data-testid="empty-state"
+        >
           No assets yet. Add one to begin.
         </div>
       ) : (

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -15,7 +15,7 @@ export default function ErrorBanner({ message, onRetry }: ErrorBannerProps) {
       {onRetry && (
         <button
           onClick={onRetry}
-          className="ml-2 text-brand-primary underline hover:text-brand-accent font-button"
+          className="ml-2 text-brand-primary underline hover:text-brand-accent font-button cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary rounded-sm"
           aria-label="Retry"
         >
           🔁 Retry

--- a/frontend/src/components/FilterSortControls/FilterSortControls.test.tsx
+++ b/frontend/src/components/FilterSortControls/FilterSortControls.test.tsx
@@ -25,4 +25,31 @@ describe("FilterSortControls", () => {
     expect(onFilterChange).toHaveBeenCalledWith("BTC");
     expect(onSortChange).toHaveBeenCalledWith("name-asc");
   });
+
+  it("disables inputs and does not call handlers when disabled", () => {
+    const onFilterChange = vi.fn();
+    const onSortChange = vi.fn();
+
+    render(
+      <FilterSortControls
+        filter=""
+        sort="value-desc"
+        onFilterChange={onFilterChange}
+        onSortChange={onSortChange}
+        disabled
+      />
+    );
+
+    const filter = screen.getByTestId("filter-input") as HTMLInputElement;
+    const sort = screen.getByTestId("sort-dropdown") as HTMLSelectElement;
+
+    expect(filter).toBeDisabled();
+    expect(sort).toBeDisabled();
+
+    fireEvent.change(filter, { target: { value: "ETH" } });
+    fireEvent.change(sort, { target: { value: "name-desc" } });
+
+    expect(onFilterChange).not.toHaveBeenCalled();
+    expect(onSortChange).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/FilterSortControls/index.tsx
+++ b/frontend/src/components/FilterSortControls/index.tsx
@@ -38,7 +38,7 @@ export default function FilterSortControls({
             onFilterChange(e.target.value);
           }}
           disabled={disabled}
-          className="pl-10 pr-3 py-2 border border-gray-200 rounded-md w-full text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-brand-primary focus:outline-none"
+          className={`pl-10 pr-3 py-2 border border-gray-200 rounded-md w-full text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-brand-primary focus:outline-none ${disabled ? "opacity-60 cursor-not-allowed" : ""}`}
         />
       </div>
 
@@ -62,7 +62,7 @@ export default function FilterSortControls({
             onSortChange(e.target.value);
           }}
           disabled={disabled}
-          className="px-3 py-2 border border-gray-200 rounded-md bg-white text-base sm:w-48 w-full focus:ring-2 focus:ring-brand-primary focus:outline-none"
+          className={`px-3 py-2 border border-gray-200 rounded-md bg-white text-base sm:w-48 w-full focus:ring-2 focus:ring-brand-primary focus:outline-none ${disabled ? "opacity-60 cursor-not-allowed" : ""}`}
         >
           <option value="value-desc">Value ⬇</option>
           <option value="value-asc">Value ⬆</option>

--- a/frontend/src/components/FilterSortControls/index.tsx
+++ b/frontend/src/components/FilterSortControls/index.tsx
@@ -5,6 +5,7 @@ export type FilterSortControlsProps = {
   onFilterChange: (value: string) => void;
   sort: string;
   onSortChange: (value: string) => void;
+  disabled?: boolean;
 };
 
 export default function FilterSortControls({
@@ -12,6 +13,7 @@ export default function FilterSortControls({
   onFilterChange,
   sort,
   onSortChange,
+  disabled = false,
 }: FilterSortControlsProps) {
   return (
     <div className="flex flex-wrap items-center gap-4 mb-4 w-full">
@@ -28,9 +30,14 @@ export default function FilterSortControls({
           type="text"
           placeholder="Search assets..."
           aria-label="Filter assets"
+          aria-disabled={disabled}
           data-testid="filter-input"
           value={filter}
-          onChange={(e) => onFilterChange(e.target.value)}
+          onChange={(e) => {
+            if (disabled) return;
+            onFilterChange(e.target.value);
+          }}
+          disabled={disabled}
           className="pl-10 pr-3 py-2 border border-gray-200 rounded-md w-full text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-brand-primary focus:outline-none"
         />
       </div>
@@ -47,9 +54,14 @@ export default function FilterSortControls({
         <select
           id="sort-assets"
           aria-label="Sort asset list"
+          aria-disabled={disabled}
           data-testid="sort-dropdown"
           value={sort}
-          onChange={(e) => onSortChange(e.target.value)}
+          onChange={(e) => {
+            if (disabled) return;
+            onSortChange(e.target.value);
+          }}
+          disabled={disabled}
           className="px-3 py-2 border border-gray-200 rounded-md bg-white text-base sm:w-48 w-full focus:ring-2 focus:ring-brand-primary focus:outline-none"
         >
           <option value="value-desc">Value ⬇</option>

--- a/frontend/src/e2e/pom-pages/portfolio.pom.ts
+++ b/frontend/src/e2e/pom-pages/portfolio.pom.ts
@@ -176,7 +176,16 @@ export class PortfolioPage {
     await this.page.reload();
   }
 
+  emptyState() {
+    // Prefer stable test id for empty state
+    return this.page.getByTestId("empty-state");
+  }
+
   async isEmptyStateVisible() {
-    return await this.page.locator("text=Your portfolio is empty.").isVisible();
+    // Match current empty state copy and be tolerant to future tweaks
+    const emptyState = this.page.getByText(
+      /No assets yet\.|No assets yet|Your portfolio is empty\./i
+    );
+    return await emptyState.isVisible();
   }
 }

--- a/frontend/src/e2e/specs/flows/persist-portfolio.spec.ts
+++ b/frontend/src/e2e/specs/flows/persist-portfolio.spec.ts
@@ -39,6 +39,6 @@ test.describe("📦 Persist Portfolio", () => {
 
     // Confirm empty state persists
     await expect(portfolioPage.assetRow("ETH")).not.toBeVisible();
-    await expect(portfolioPage.isEmptyStateVisible()).toBeTruthy();
+    await expect(portfolioPage.emptyState()).toBeVisible();
   });
 });

--- a/frontend/src/e2e/specs/flows/refreshing-disabled-controls.spec.ts
+++ b/frontend/src/e2e/specs/flows/refreshing-disabled-controls.spec.ts
@@ -1,0 +1,74 @@
+import { test as base, expect, Page } from "@playwright/test";
+
+async function mockMarketsWithDelayedRefresh(page: Page, delayMs = 800) {
+  let callCount = 0;
+  // Remove any existing routes for the markets endpoint (in case fixtures added one)
+  try {
+    await page.unroute("**/api.coingecko.com/api/v3/coins/markets**");
+  } catch {}
+
+  await page.route("**/api.coingecko.com/api/v3/coins/markets**", async (route) => {
+    callCount++;
+    const body = [
+      {
+        id: "bitcoin",
+        symbol: "btc",
+        name: "Bitcoin",
+        current_price: 30000,
+        image: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png",
+      },
+      {
+        id: "ethereum",
+        symbol: "eth",
+        name: "Ethereum",
+        current_price: 2000,
+        image: "https://assets.coingecko.com/coins/images/279/large/ethereum.png",
+      },
+    ];
+
+    // First call: respond immediately to complete initial loading
+    // Subsequent calls: delay to keep refreshing state observable
+    if (callCount > 1) await new Promise((r) => setTimeout(r, delayMs));
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+// Traceability: UI States — refreshing disables controls, sets aria-busy, shows lightweight updating indicator
+base.describe("Refreshing state disables controls and sets aria-busy", () => {
+  base("during background refresh, controls disabled and main has aria-busy=true", async ({ page }) => {
+    // Ensure polling is short; CI uses script with VITE_POLL_INTERVAL=2000 already
+    await mockMarketsWithDelayedRefresh(page, 1000);
+
+    await page.goto("/?e2e=1");
+
+    // Wait for initial load to complete (header visible and controls enabled)
+    await expect(page.getByText(/Total Portfolio Value/i)).toBeVisible();
+
+    const filterInput = page.getByPlaceholder("Search assets...");
+    const sortDropdown = page.getByTestId("sort-dropdown");
+    const addAssetButton = page.getByTestId("add-asset-button");
+
+    await expect(filterInput).toBeEnabled();
+    await expect(sortDropdown).toBeEnabled();
+    await expect(addAssetButton).toBeEnabled();
+
+    // Trigger a deterministic refresh via test-only button
+    await page.getByTestId("refresh-now").click();
+    // Observe aria-busy=true on main during refresh
+    const busyMain = page.locator("main[aria-busy='true']").first();
+    await busyMain.waitFor({ state: "visible", timeout: 8000 });
+
+    await expect(filterInput).toBeDisabled();
+    await expect(sortDropdown).toBeDisabled();
+    await expect(addAssetButton).toBeDisabled();
+
+    // After refresh completes, aria-busy should be removed and controls re-enable
+    await busyMain.waitFor({ state: "detached", timeout: 8000 });
+    await expect(page.locator("main[aria-busy='true']")).toHaveCount(0);
+
+    await expect(filterInput).toBeEnabled();
+    await expect(sortDropdown).toBeEnabled();
+    await expect(addAssetButton).toBeEnabled();
+  });
+});

--- a/frontend/src/e2e/specs/flows/retry-reenable-controls.spec.ts
+++ b/frontend/src/e2e/specs/flows/retry-reenable-controls.spec.ts
@@ -1,0 +1,49 @@
+import { test as base, expect, Page } from "@playwright/test";
+
+// Custom helper to fail first and then succeed after retry
+async function mockMarketsFailThenSucceed(page: Page) {
+  let callCount = 0;
+  await page.route("**/api.coingecko.com/api/v3/coins/markets**", async (route) => {
+    callCount++;
+    if (callCount === 1) {
+      // First call fails
+      return route.fulfill({ status: 500, contentType: "application/json", body: JSON.stringify({ error: "fail" }) });
+    }
+    // Subsequent calls succeed with static data
+    const body = [
+      { id: "bitcoin", symbol: "btc", name: "Bitcoin", current_price: 30000, image: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png" },
+      { id: "ethereum", symbol: "eth", name: "Ethereum", current_price: 2000, image: "https://assets.coingecko.com/coins/images/279/large/ethereum.png" },
+    ];
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+base.describe("Retry flow clears error and re-enables controls", () => {
+  base("error shown initially, retry succeeds, controls usable before and after", async ({ page }) => {
+    await mockMarketsFailThenSucceed(page);
+
+    // Navigate to app
+    await page.goto("/");
+
+    // Expect error banner visible
+    const retryButton = page.getByRole("button", { name: /retry/i });
+    await expect(retryButton).toBeVisible();
+
+    // Controls remain enabled while error is present (disabled only during loading/refreshing)
+    const filterInput = page.getByPlaceholder("Search assets...");
+    const sortDropdown = page.getByTestId("sort-dropdown");
+    const addAssetButton = page.getByTestId("add-asset-button");
+
+    await expect(filterInput).toBeEnabled();
+    await expect(sortDropdown).toBeEnabled();
+    await expect(addAssetButton).toBeEnabled();
+
+    // Click Retry -> next request succeeds, error should disappear and controls enabled
+    await retryButton.click();
+
+    await expect(retryButton).toHaveCount(0);
+    await expect(filterInput).toBeEnabled();
+    await expect(sortDropdown).toBeEnabled();
+    await expect(addAssetButton).toBeEnabled();
+  });
+});

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -79,10 +79,15 @@ export default function PortfolioPage() {
     priceMap: priceMap as Record<string, number>,
   });
 
+  const e2eMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("e2e") === "1";
+
   if (loading) {
     return (
       <main
         role="main"
+        aria-busy={true}
         className="flex flex-col justify-center items-center h-screen text-center"
       >
         <LoadingSpinner label=" Loading portfolio..." fullScreen />
@@ -114,6 +119,20 @@ export default function PortfolioPage() {
         </div>
       )}
 
+      {/* Test-only control to trigger deterministic refresh in E2E */}
+      {e2eMode && (
+        <div className="w-full max-w-4xl mx-auto px-6 md:px-10 mb-2">
+          <button
+            type="button"
+            onClick={retry}
+            className="text-sm text-brand-primary underline"
+            data-testid="refresh-now"
+          >
+            Refresh now
+          </button>
+        </div>
+      )}
+
       {(error || importError) && (
         <ErrorBanner
           message=" Error loading prices. Please try again later."
@@ -138,6 +157,7 @@ export default function PortfolioPage() {
       </div>
       <main
         role="main"
+        aria-busy={refreshing}
         className="max-w-4xl mx-auto p-6 md:p-10 bg-surface rounded-lg shadow-lg flex flex-col gap-8 text-balance"
       >
         <section className="flex flex-col gap-6 w-full">

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -133,6 +133,7 @@ export default function PortfolioPage() {
           onFilterChange={setFilterText}
           sort={sortOption}
           onSortChange={setSortOption}
+          disabled={!!(loading || refreshing)}
         />
       </div>
       <main

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -22,7 +22,7 @@ import { usePortfolioImportExport } from "@hooks/usePortfolioImportExport";
 
 export default function PortfolioPage() {
   // 1. Fetch + poll coin data
-  const { coins: allCoins, loading, error, lastUpdatedAt } = useCoinList();
+  const { coins: allCoins, loading, error, lastUpdatedAt, refreshing, retry } = useCoinList();
 
   // 2. Derive price map for portfolio valuation
   const priceMap = usePriceMap(allCoins);
@@ -107,8 +107,18 @@ export default function PortfolioPage() {
         className="flex items-center justify-between mb-4"
       />
 
+      {/* Lightweight updating indicator during background refreshes */}
+      {refreshing && (
+        <div className="w-full max-w-4xl mx-auto px-6 md:px-10 -mt-2 mb-2" aria-live="polite">
+          <LoadingSpinner label=" Updating prices…" />
+        </div>
+      )}
+
       {(error || importError) && (
-        <ErrorBanner message=" Error loading prices. Please try again later." />
+        <ErrorBanner
+          message=" Error loading prices. Please try again later."
+          onRetry={retry}
+        />
       )}
       {importError && (
         <div className="max-w-4xl mx-auto px-6 md:px-10 mt-2">
@@ -137,6 +147,7 @@ export default function PortfolioPage() {
             onAddAsset={openAddAssetModal}
             addButtonRef={addButtonRef}
             priceMap={priceMap}
+            disabled={!!(loading || refreshing)}
           />
 
           {/* Footer Action Buttons */}


### PR DESCRIPTION
Title: feat(ui-states): accessible loading, error, and refreshing states with deterministic E2E
Date: 2025-08-24
Status: Ready to Merge

## Summary
Implements robust, accessible UI states for the Portfolio page: initial loading, background refreshing, and error with Retry. Adds `aria-busy` during load/refresh, keeps controls usable during error states, and provides subtle disabled visuals during refresh. Improves E2E reliability with a test-only deterministic Refresh trigger. Empty state now has a stable `data-testid`.

## Changes
- Accessibility: `aria-busy` on main container during initial load and background refresh
- Error handling: Error banner with Retry action; controls remain enabled on error
- UX: Disabled affordances on controls during refresh (`opacity-60`, `cursor-not-allowed`)
- Testing: Deterministic refresh in E2E via `/?e2e=1` and `data-testid="refresh-now"`
- Testing: Stable empty state selector via `data-testid="empty-state"`

## Files Changed
- Frontend
  - [frontend/src/pages/PortfolioPage.tsx](cci:7://file:///Users/nati/Projects/crypture/frontend/src/pages/PortfolioPage.tsx:0:0-0:0) (aria-busy, error/refresh UI, test-only refresh control)
  - [frontend/src/components/AssetList/index.tsx](cci:7://file:///Users/nati/Projects/crypture/frontend/src/components/AssetList/index.tsx:0:0-0:0) (empty state test id)
  - `frontend/src/components/FilterSortControls/` (disabled visuals)
  - `frontend/src/components/ErrorBanner.tsx` (retry wiring)
  - [frontend/src/hooks/useCoinList.ts](cci:7://file:///Users/nati/Projects/crypture/frontend/src/hooks/useCoinList.ts:0:0-0:0) (exposes `refreshing`, `retry`)
- Tests
  - [frontend/src/e2e/specs/flows/retry-reenable-controls.spec.ts](cci:7://file:///Users/nati/Projects/crypture/frontend/src/e2e/specs/flows/retry-reenable-controls.spec.ts:0:0-0:0) (retry flow)
  - [frontend/src/e2e/specs/flows/refreshing-disabled-controls.spec.ts](cci:7://file:///Users/nati/Projects/crypture/frontend/src/e2e/specs/flows/refreshing-disabled-controls.spec.ts:0:0-0:0) (deterministic and passing)
  - [frontend/src/e2e/pom-pages/portfolio.pom.ts](cci:7://file:///Users/nati/Projects/crypture/frontend/src/e2e/pom-pages/portfolio.pom.ts:0:0-0:0) (use `getByTestId('empty-state')`)
  - [frontend/src/e2e/specs/flows/persist-portfolio.spec.ts](cci:7://file:///Users/nati/Projects/crypture/frontend/src/e2e/specs/flows/persist-portfolio.spec.ts:0:0-0:0) (use stable empty state locator)
- Docs
  - [docs/sprint-planning.md](cci:7://file:///Users/nati/Projects/crypture/docs/sprint-planning.md:0:0-0:0) (Story 7 section updated to Done; test notes)

## Acceptance Criteria (Story 7)
- [x] 7.1 Initial load shows a prominent loading indicator; controls disabled
- [x] 7.2 Background refresh sets `aria-busy` and disables controls with subtle visuals
- [x] 7.3 On fetch error, an error banner appears with Retry
- [x] 7.4 Retry clears error and data loads; controls usable after recovery
- [x] 7.5 A11y: appropriate `aria-busy`, `role="alert"`, and disabled affordances

## How to Test
- E2E: `npm run test:e2e` → ensures retry and refreshing-state specs pass
- Manual:
  - Load app: initial spinner shows; controls disabled until data loads
  - Navigate to `/?e2e=1` then click “Refresh now” → observe `aria-busy=true` and disabled controls during refresh
  - Simulate network error → error banner with Retry appears; clicking Retry restores data

## Notes
- Test-only refresh control gated by `?e2e=1` and hidden in normal usage
- Empty state has `data-testid="empty-state"` to keep E2E selectors stable across copy changes

## Linked Work
- Sprint Planning: [docs/sprint-planning.md](cci:7://file:///Users/nati/Projects/crypture/docs/sprint-planning.md:0:0-0:0) (User Story 7 section)